### PR TITLE
Fixed 404 to non existent polymer package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To use it, you need to:
   * run the tool via `pub run custom_element_apigen:update configfile.yaml`
 
 There is not much documentation written for this tool. You can find examples of
-how this tool is used in the [polymer-elements][1] package.
+how this tool is used in the [core-elements][1] and [paper-elements][2] packages.
 
-[1]: https://github.com/dart-lang/polymer-elements/
+[1]: https://github.com/dart-lang/core-elements/
+[2]: https://github.com/dart-lang/paper-elements/


### PR DESCRIPTION
Now points to core and paper elements, where this package can be seen
in action.