### PR TITLE
added option for extra imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-## 0.2.1+1
+## 0.2.2
+
+  * Added a new option to add extra imports on the dart side. Usefull when
+    the generated import is wrong and you need to omit it and replace with
+    the right one:
+
+      - some_file/some_file.html:
+         extra_imports:
+          - package:polymer_elements/iron_resizable_behavior.dart
+         
+# 0.2.1+1
   * Make sure we handle duplicate behavior/element names that come back from the
     `hydrolysis` tool. This happens when there is an `Impl` class and a public
     class by the same name.

--- a/lib/src/codegen.dart
+++ b/lib/src/codegen.dart
@@ -182,6 +182,11 @@ String generateDirectives(String name, List<String> segments,
       .withoutExtension(segments.map((s) => s.replaceAll('-', '_')).join('.'));
   var elementName = name.replaceAll('-', '_');
   var extraImports = new Set<String>();
+  if (config.extraImports!=null) {
+    config.extraImports.forEach((pkg) {
+      extraImports.add("import '$pkg';");
+    });
+  }
 
   // Given a mixin, adds imports for it and all its recursive dependencies.
   addMixinImports(String mixinName) {

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -63,6 +63,9 @@ class FileConfig {
   /// corresponding Dart type.
   final List<String> omitImports;
 
+  /// extra imports
+  final List<String> extraImports;
+
   /// Map of file names to classes that should live within them. All other
   /// classes will end up in the default file.
   final Map<String, List<String>> file_overrides;
@@ -87,6 +90,7 @@ class FileConfig {
   FileConfig(this.global, this.inputPath, [Map map])
       : nameSubstitutions = map != null ? map['name_substitutions'] : null,
         omitImports = map != null ? map['omit_imports'] : null,
+        extraImports = map != null ? map['extra_imports'] : null,
         extendsImport = map != null ? map['extends_import'] : null,
         file_overrides = map != null ? map['file_overrides'] : null,
         typeOverrides = map != null ? map['type_overrides'] : null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: custom_element_apigen
-version: 0.2.1+1
+version: 0.2.2
 author: Polymer.dart Authors <web-ui-dev@dartlang.org>
 description: Generates Dart API for JS Custom Elements
 homepage: https://github.com/dart-lang/custom-element-apigen


### PR DESCRIPTION
Added an handfull option to add extra imports when generationg classes.

This is usefull for example when we need to load a mixin file but the generated import is wrong so we need to omit it and replace with the right one (I had this problem with `iron-resizable-behavior`).